### PR TITLE
check if current network interface is UP

### DIFF
--- a/app/src/main/java/dnsfilter/android/DNSFilterService.java
+++ b/app/src/main/java/dnsfilter/android/DNSFilterService.java
@@ -132,7 +132,7 @@ public class DNSFilterService extends VpnService  {
 					InetAddress adr = (InetAddress) ips.nextElement();
 					if (!adr.isLoopbackAddress() && adr instanceof Inet4Address) {
 						String ipStr = adr.getHostAddress();
-						if (nif.getName().startsWith("tun"))
+						if (nif.getName().startsWith("tun") && nif.isUp())
 							return ipStr; //prefer vpn interface in order to work together with real VPN
 						else if (ip == null)
 							ip = ipStr;


### PR DESCRIPTION
fixes a rare issue of detecting correct vpn interface IP while running in root mode Android.